### PR TITLE
c.c.repl-utils/show is currently broken

### DIFF
--- a/modules/repl-utils/src/main/clojure/clojure/contrib/repl_utils.clj
+++ b/modules/repl-utils/src/main/clojure/clojure/contrib/repl_utils.clj
@@ -17,6 +17,7 @@
   clojure.contrib.repl-utils
   (:import (java.io File LineNumberReader InputStreamReader PushbackReader)
            (java.lang.reflect Modifier Method Constructor)
+           (java.util.regex Pattern)
            (clojure.lang RT Compiler Compiler$C))
   (:use [clojure.contrib.seq :only (indexed)]
         [clojure.java.browse :only (browse-url)]
@@ -48,7 +49,7 @@
 
 (defn- sortable [t]
   (apply str (map (fn [[a b]] (str a (format "%04d" (Integer. b))))
-                  (spartition 2 (concat (spartition #"\d+" t) [0])))))
+                  (partition 2 (concat (spartition #"\d+" t) [0])))))
 
 (defn- param-str [m]
   (str " (" (join


### PR DESCRIPTION
since the module reorganisation:

commit fe4ed311166677cd571d23774171af1d830f7fc5
Author: Ben Smith-Mannschott bsmith.occs@gmail.com
Date:   Sat Aug 28 11:22:22 2010 +0200
