### PR TITLE
Naming projects

### DIFF
--- a/modules/accumulators/pom.xml
+++ b/modules/accumulators/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>accumulators</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/agent-utils/pom.xml
+++ b/modules/agent-utils/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>agent-utils</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/base64/pom.xml
+++ b/modules/base64/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>base64</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/classpath/pom.xml
+++ b/modules/classpath/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>classpath</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/combinatorics/pom.xml
+++ b/modules/combinatorics/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>combinatorics</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/command-line/pom.xml
+++ b/modules/command-line/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>command-line</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/complete/pom.xml
+++ b/modules/complete/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>complete</artifactId>
+  <name>${artifactId}</name>
   <packaging>jar</packaging>
   <dependencies>
     <dependency>

--- a/modules/complex-numbers/pom.xml
+++ b/modules/complex-numbers/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>complex-numbers</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/cond/pom.xml
+++ b/modules/cond/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>cond</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/condition/pom.xml
+++ b/modules/condition/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>condition</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <!-- AOT-compilation necessitates a specific Clojure dependency. -->
     <dependency>

--- a/modules/core/pom.xml
+++ b/modules/core/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>core</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/dataflow/pom.xml
+++ b/modules/dataflow/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>dataflow</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/datalog/pom.xml
+++ b/modules/datalog/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>datalog</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/def/pom.xml
+++ b/modules/def/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>def</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/error-kit/pom.xml
+++ b/modules/error-kit/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>error-kit</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/except/pom.xml
+++ b/modules/except/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>except</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/fcase/pom.xml
+++ b/modules/fcase/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>fcase</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/find-namespaces/pom.xml
+++ b/modules/find-namespaces/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>find-namespaces</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/fnmap/pom.xml
+++ b/modules/fnmap/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>fnmap</artifactId>
+  <name>${artifactId}</name>
   <build>
     <plugins>
       <plugin>

--- a/modules/gen-html-docs/pom.xml
+++ b/modules/gen-html-docs/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>gen-html-docs</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/generic/pom.xml
+++ b/modules/generic/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>generic</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/graph/pom.xml
+++ b/modules/graph/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>graph</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/greatest-least/pom.xml
+++ b/modules/greatest-least/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>greatest-least</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/import-static/pom.xml
+++ b/modules/import-static/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>import-static</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/jar/pom.xml
+++ b/modules/jar/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>jar</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/java-utils/pom.xml
+++ b/modules/java-utils/pom.xml
@@ -11,6 +11,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>java-utils</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/jmx/pom.xml
+++ b/modules/jmx/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>jmx</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <!-- AOT-compilation necessitates a specific Clojure dependency. -->
     <dependency>

--- a/modules/json/pom.xml
+++ b/modules/json/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>json</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/lazy-seqs/pom.xml
+++ b/modules/lazy-seqs/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>lazy-seqs</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/lazy-xml/pom.xml
+++ b/modules/lazy-xml/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>lazy-xml</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/logging/pom.xml
+++ b/modules/logging/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>logging</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/macro-utils/pom.xml
+++ b/modules/macro-utils/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>macro-utils</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/macros/pom.xml
+++ b/modules/macros/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>macros</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/map-utils/pom.xml
+++ b/modules/map-utils/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>map-utils</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/math/pom.xml
+++ b/modules/math/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>math</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/miglayout/pom.xml
+++ b/modules/miglayout/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>miglayout</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/mmap/pom.xml
+++ b/modules/mmap/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>mmap</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/mock/pom.xml
+++ b/modules/mock/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>mock</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/monadic-io-streams/pom.xml
+++ b/modules/monadic-io-streams/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>monadic-io-streams</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/monads/pom.xml
+++ b/modules/monads/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>monads</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/ns-utils/pom.xml
+++ b/modules/ns-utils/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>ns-utils</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/priority-map/pom.xml
+++ b/modules/priority-map/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>priority-map</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/probabilities/pom.xml
+++ b/modules/probabilities/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>probabilities</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/profile/pom.xml
+++ b/modules/profile/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>profile</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/prxml/pom.xml
+++ b/modules/prxml/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>prxml</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/reflect/pom.xml
+++ b/modules/reflect/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>reflect</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/repl-ln/pom.xml
+++ b/modules/repl-ln/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>repl-ln</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <!-- AOT-compilation necessitates a specific Clojure dependency. -->
     <dependency>
@@ -24,15 +25,15 @@
   <build>
     <plugins>
       <plugin>
-	<groupId>com.theoryinpractise</groupId>
-	<artifactId>clojure-maven-plugin</artifactId>
-	<configuration>
-	  <temporaryOutputDirectory>false</temporaryOutputDirectory>
-	  <compileDeclaredNamespaceOnly>true</compileDeclaredNamespaceOnly>
-	  <namespaces>
-	    <namespace>clojure\.contrib\.repl-ln</namespace>
-	  </namespaces>
-	</configuration>
+        <groupId>com.theoryinpractise</groupId>
+        <artifactId>clojure-maven-plugin</artifactId>
+        <configuration>
+          <temporaryOutputDirectory>false</temporaryOutputDirectory>
+          <compileDeclaredNamespaceOnly>true</compileDeclaredNamespaceOnly>
+          <namespaces>
+            <namespace>clojure\.contrib\.repl-ln</namespace>
+          </namespaces>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/modules/repl-utils/pom.xml
+++ b/modules/repl-utils/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>repl-utils</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/seq/pom.xml
+++ b/modules/seq/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>seq</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/server-socket/pom.xml
+++ b/modules/server-socket/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>server-socket</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/set/pom.xml
+++ b/modules/set/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>set</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/singleton/pom.xml
+++ b/modules/singleton/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>singleton</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/sql/pom.xml
+++ b/modules/sql/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>sql</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/standalone/pom.xml
+++ b/modules/standalone/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>standalone</artifactId>
+  <name>${artifactId}</name>
   <packaging>jar</packaging>
   <build>
     <plugins>

--- a/modules/stream-utils/pom.xml
+++ b/modules/stream-utils/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>stream-utils</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/strint/pom.xml
+++ b/modules/strint/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>strint</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/swing-utils/pom.xml
+++ b/modules/swing-utils/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>swing-utils</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/trace/pom.xml
+++ b/modules/trace/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>trace</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/types/pom.xml
+++ b/modules/types/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>types</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
     <dependency>
       <groupId>org.clojure.contrib</groupId>

--- a/modules/with-ns/pom.xml
+++ b/modules/with-ns/pom.xml
@@ -8,6 +8,7 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>with-ns</artifactId>
+  <name>${artifactId}</name>
   <dependencies>
   </dependencies>
 </project>

--- a/modules/zip-filter/pom.xml
+++ b/modules/zip-filter/pom.xml
@@ -8,4 +8,5 @@
     <relativePath>../parent</relativePath>
   </parent>
   <artifactId>zip-filter</artifactId>
+  <name>${artifactId}</name>
 </project>


### PR DESCRIPTION
Adding **name** property to all pom files by using the already set **artifactId**. Should clean up a few issues in project naming in some IDEs.
