### PR TITLE
c.c.Profile using long instead of int

### DIFF
--- a/modules/profile/src/main/clojure/clojure/contrib/profile.clj
+++ b/modules/profile/src/main/clojure/clojure/contrib/profile.clj
@@ -85,7 +85,7 @@ profiling code."}  *enable-profiling* true)
   (reduce (fn [m [k v]]
             (let [cnt (count v)
                   sum (reduce + v)]
-              (assoc m k {:mean (int (/ sum cnt))
+              (assoc m k {:mean (long (/ sum cnt))
                           :min (apply min v)
                           :max (apply max v)
                           :count cnt

--- a/modules/profile/src/test/clojure/clojure/contrib/test_profile.clj
+++ b/modules/profile/src/test/clojure/clojure/contrib/test_profile.clj
@@ -6,3 +6,14 @@
   (testing "doesn't blow up with no data (assembla #31)"
     (is (= "Name      mean       min       max     count       sum\n"
            (with-out-str (print-summary {}))))))
+
+(deftest can-summarize-profile-data
+  (testing "summarizing a quick method"
+    (is (= {:really-quick-operation {:mean 6, :min 0, :max 40, :count 7, :sum 46}}
+           (summarize {:really-quick-operation (list 0 0 1 1 2 2 40)}))))
+
+  (testing "summarizing a slow method"
+    (let [long-time (+ Integer/MAX_VALUE 1)]
+     (is (= {:really-quick-operation {:mean long-time, :min long-time, :max long-time, :count 1, :sum long-time}}
+            (summarize {:really-slow-operation (list  long-time)}))))))
+

--- a/modules/profile/src/test/clojure/clojure/contrib/test_profile.clj
+++ b/modules/profile/src/test/clojure/clojure/contrib/test_profile.clj
@@ -14,6 +14,6 @@
 
   (testing "summarizing a slow method"
     (let [long-time (+ Integer/MAX_VALUE 1)]
-     (is (= {:really-quick-operation {:mean long-time, :min long-time, :max long-time, :count 1, :sum long-time}}
+     (is (= {:really-slow-operation {:mean long-time, :min long-time, :max long-time, :count 1, :sum long-time}}
             (summarize {:really-slow-operation (list  long-time)}))))))
 


### PR DESCRIPTION
Quick fix for some problems I had while profiling some slow functions. Casting division to long instead of int, also added test cases.

First commit has a failing test case. Second commit has my fix.

Cheers
